### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push-again.yml
+++ b/.github/workflows/push-again.yml
@@ -1,4 +1,6 @@
 name: Re-push image
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Rose2161/images/security/code-scanning/2](https://github.com/Rose2161/images/security/code-scanning/2)

To fix the error, you should explicitly set the least privilege required for `GITHUB_TOKEN` by adding a `permissions:` block. This can be accomplished at either the workflow root (to apply to all jobs), or at the job (`build-and-push:`) level. Conventionally, setting at the root is preferable for single-job workflows. The minimal required permission for the existing steps is `contents: read`, as the workflow only needs to check out the repository contents. No other access is needed for issues, pull requests, or workflows.  
**Implementation:**  
- Add the following block after the `name` line (before `on:`) in `.github/workflows/push-again.yml`:
  ```yaml
  permissions:
    contents: read
  ```
- No other changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
